### PR TITLE
fix: Specify host for preview server to avoid EAFNOSUPPORT error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
     "12": "^1.0.2",


### PR DESCRIPTION
The preview server was failing to start with an `EAFNOSUPPORT` error because it was trying to listen on an IPv6 address which is not supported in the environment.

This change modifies the `preview` script in `package.json` to explicitly use `127.0.0.1` as the host, which is the IPv4 loopback address. This resolves the server startup issue.

Note: The codebase has a large number of pre-existing lint errors that are unrelated to this change.