### PR TITLE
feat: Add direct profile switching

### DIFF
--- a/src/components/match/MatchAnalysisSidebar.tsx
+++ b/src/components/match/MatchAnalysisSidebar.tsx
@@ -42,7 +42,7 @@ const MatchAnalysisSidebar: FC<MatchAnalysisSidebarProps> = ({
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, signOut } = useAuth();
+  const { user, signOut, switchUser } = useAuth();
   const { permissions, role, isLoading, hasPermission, isAdmin } = usePermissionChecker();
 
   const handleItemClick = (item: MenuItem) => {
@@ -156,9 +156,7 @@ const MatchAnalysisSidebar: FC<MatchAnalysisSidebarProps> = ({
                     <SidebarMenuButton
                       onClick={() => {
                         const targetEmail = user.email === 'adminzack@efoot.com' ? 'excelzed@gmail.com' : 'adminzack@efoot.com';
-                        signOut().then(() => {
-                          navigate(`/auth?email=${targetEmail}`);
-                        });
+                        switchUser(targetEmail, '123456');
                       }}
                       tooltip="Switch Profile"
                       className="h-10 justify-start group-data-[state=collapsed]:justify-center !bg-transparent text-white hover:!bg-white/10"

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -13,6 +13,7 @@ interface AuthContextType {
   signOut: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<void>;
   signUp: (email: string, password: string, fullName?: string) => Promise<void>;
+  switchUser: (email: string, password: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -134,6 +135,11 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     setUserRole(null);
   };
 
+  const switchUser = async (email: string, password: string) => {
+    await signOut();
+    await signIn(email, password);
+  };
+
   const value = {
     user,
     session,
@@ -142,6 +148,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     signOut,
     signIn,
     signUp,
+    switchUser,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type FormEvent } from 'react';
-import { useNavigate, Navigate, useLocation } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -20,16 +20,6 @@ const Auth = () => {
   const [googleLoading, setGoogleLoading] = useState(false);
   const navigate = useNavigate();
   const { toast } = useToast();
-  const location = useLocation();
-
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const emailFromQuery = params.get('email');
-    if (emailFromQuery) {
-      setEmail(emailFromQuery);
-      setActiveTab('login');
-    }
-  }, [location.search]);
 
   // Redirect if already logged in
   if (user) {


### PR DESCRIPTION
This adds a profile switching button to the sidebar for the users 'adminzack@efoot.com' and 'excelzed@gmail.com'.

When the button is clicked, it directly switches to the other user's profile using a hardcoded password, as requested by the user.