### PR TITLE
feat: Rebuild landing page and set as root route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,12 +83,12 @@ const AppContent = () => {
       <Header />
       <Routes>
         {/* Public routes */}
-        <Route path="/landing" element={<LandingPage />} />
+        <Route path="/" element={<LandingPage />} />
         <Route path="/auth" element={<Auth />} />
         <Route path="/extension-bridge" element={<ChromeExtensionBridge />} />
 
         {/* Protected routes - General Access */}
-        <Route path="/" element={
+        <Route path="/dashboard" element={
           <RequireAuth>
             <Dashboard />
           </RequireAuth>
@@ -268,7 +268,7 @@ const AppContent = () => {
                   Go Back
                 </button>
                 <button 
-                  onClick={() => navigate('/')}
+                  onClick={() => navigate('/dashboard')}
                   className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
                 >
                   Dashboard

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -48,7 +48,7 @@ const Dashboard = () => {
 
   // Sidebar menu items are only generated based on permissions, not roles!
   const menuItems = [
-    { value: 'dashboard', label: 'Dashboard', icon: LayoutDashboard, path: '/' }
+    { value: 'dashboard', label: 'Dashboard', icon: LayoutDashboard, path: '/dashboard' }
   ];
 
   // New Match visible if user has canCreateMatches permission


### PR DESCRIPTION
This commit implements two main changes:
1. Rebuilds the landing page content to be specifically tailored for the Algerian football market, based on the provided business context. This includes updating the hero section, feature descriptions, pricing plans (in DZD), and target audience.
2. Changes the application routing to serve the new landing page from the root path (`/`). The authenticated dashboard has been moved from `/` to `/dashboard`, and all relevant navigation links have been updated accordingly.