### PR TITLE
feat: Add business intelligence pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,11 @@ import NotFound from './pages/NotFound';
 import VideoSetupPage from './pages/Admin/VideoSetupPage';
 import Scouting from './pages/Scouting';
 import ClubDetails from './components/scouting/ClubDetails';
+import MarketIntelligencePage from './pages/MarketIntelligencePage';
+import BusinessPlanPage from './pages/BusinessPlanPage';
+import StartupPitchPage from './pages/StartupPitchPage';
+import BusinessModelCanvasPage from './pages/BusinessModelCanvas';
+import ServiceOfferPage from './pages/ServiceOffer';
 
 const queryClient = new QueryClient();
 
@@ -262,6 +267,33 @@ const AppContent = () => {
             >
                 <ClubDetails />
             </RequireAuth>
+        } />
+
+        {/* Business Routes */}
+        <Route path="/business/market-intelligence" element={
+          <RequireAuth requiredRoles={['admin', 'manager']}>
+            <MarketIntelligencePage />
+          </RequireAuth>
+        } />
+        <Route path="/business/plan" element={
+          <RequireAuth requiredRoles={['admin', 'manager']}>
+            <BusinessPlanPage />
+          </RequireAuth>
+        } />
+        <Route path="/business/pitch" element={
+          <RequireAuth requiredRoles={['admin', 'manager']}>
+            <StartupPitchPage />
+          </RequireAuth>
+        } />
+        <Route path="/business/canvas" element={
+          <RequireAuth requiredRoles={['admin', 'manager']}>
+            <BusinessModelCanvasPage />
+          </RequireAuth>
+        } />
+        <Route path="/business/service-offer" element={
+          <RequireAuth requiredRoles={['admin', 'manager']}>
+            <ServiceOfferPage />
+          </RequireAuth>
         } />
 
         {/* Communication Routes */}

--- a/src/components/admin/ErrorManager.tsx
+++ b/src/components/admin/ErrorManager.tsx
@@ -31,7 +31,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { usePermissionChecker } from '@/hooks/usePermissionChecker';
 import { toast } from '@/hooks/use-toast';
 import { format } from 'date-fns';
-import { User } from '@supabase/supabase-js';
+import type { User } from '@supabase/auth-helpers-nextjs';
 
 interface ErrorLog {
   id: string;

--- a/src/hooks/useMenuItems.ts
+++ b/src/hooks/useMenuItems.ts
@@ -1,6 +1,6 @@
 
 import { useMemo } from 'react';
-import { LayoutDashboard, Play, Calendar, BarChart3, TrendingUp, Target, Eye, Network, AlertTriangle } from 'lucide-react';
+import { LayoutDashboard, Play, Calendar, BarChart3, TrendingUp, Target, Eye, Network, AlertTriangle, Briefcase, DollarSign } from 'lucide-react';
 import { usePermissionChecker } from './usePermissionChecker';
 import { type RolePermissions } from './useUserPermissions';
 
@@ -73,6 +73,40 @@ export const useMenuItems = () => {
         label: 'Scouting', 
         icon: Eye, 
         path: '/scouting'
+      });
+    }
+
+    // Add business pages for admins and managers
+    if (isAdmin() || hasPermission('canViewAnalytics')) { // Using same logic as scouting
+      items.push({
+        value: 'business-plan',
+        label: 'Business Plan',
+        icon: Briefcase,
+        path: '/business/plan'
+      });
+      items.push({
+        value: 'market-intelligence',
+        label: 'Market Study',
+        icon: Eye, // Using Eye icon like scouting
+        path: '/business/market-intelligence'
+      });
+      items.push({
+        value: 'pitch-deck',
+        label: 'Presentation',
+        icon: TrendingUp, // Using TrendingUp icon like analytics
+        path: '/business/pitch'
+      });
+      items.push({
+        value: 'business-canvas',
+        label: 'Business Canvas',
+        icon: LayoutDashboard, // Using Dashboard icon
+        path: '/business/canvas'
+      });
+      items.push({
+        value: 'service-offer',
+        label: 'Service Offer',
+        icon: DollarSign,
+        path: '/business/service-offer'
       });
     }
     

--- a/src/pages/BusinessModelCanvas.tsx
+++ b/src/pages/BusinessModelCanvas.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Briefcase, Users, Zap, DollarSign, Key, Heart, MessageSquare, Truck, BarChart2 } from 'lucide-react';
+
+const BusinessModelCanvasPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-12 px-4 md:px-6">
+      <div className="text-center mb-12">
+        <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl">Business Model Canvas</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          A strategic management template for developing new or documenting existing business models.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* Left Column */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg"><Briefcase className="h-5 w-5 text-primary" /> Key Partnerships</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                <li>Fédération Algérienne de Football (FAF)</li>
+                <li>Regional Leagues</li>
+                <li>Professional Football Clubs</li>
+                <li>Training Centers & Academies</li>
+                <li>Technology Providers (LiveKit, Supabase)</li>
+              </ul>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg"><Zap className="h-5 w-5 text-primary" /> Key Activities</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                  <li>Platform Development & Maintenance</li>
+                  <li>Real-time Data Tracking & Analysis</li>
+                  <li>User Training & Support</li>
+                  <li>Sales & Marketing</li>
+                  <li>R&D for AI/ML Features</li>
+              </ul>
+            </CardContent>
+          </Card>
+           <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg"><Key className="h-5 w-5 text-primary" /> Key Resources</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                <li>Proprietary Software Platform</li>
+                <li>Skilled Development Team</li>
+                <li>Network of Trained Match Trackers</li>
+                <li>Cloud Infrastructure (Supabase, LiveKit)</li>
+                <li>Strategic Partnerships</li>
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Center Column */}
+        <div className="space-y-4">
+          <Card className="h-full">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg"><Heart className="h-5 w-5 text-primary" /> Value Propositions</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside text-sm text-muted-foreground space-y-2">
+                <li><strong>Real-time Collaboration:</strong> First platform in Algeria for simultaneous multi-user match tracking.</li>
+                <li><strong>Affordable & Accessible:</strong> SaaS model tailored to local club budgets.</li>
+                <li><strong>All-in-One Solution:</strong> Combines video analysis, voice chat, and live data tracking.</li>
+                <li><strong>Data-Driven Decisions:</strong> Empowers coaches with advanced analytics and visualizations.</li>
+                 <li><strong>Local Support:</strong> On-the-ground training and technical support in Algeria.</li>
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right Column */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg"><MessageSquare className="h-5 w-5 text-primary" /> Customer Relationships</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                <li>Dedicated Account Managers</li>
+                <li>On-site & Remote Training</li>
+                <li>Priority Support (Premium/Enterprise)</li>
+                <li>Community Forum & Workshops</li>
+              </ul>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg"><Truck className="h-5 w-5 text-primary" /> Channels</CardTitle>
+            </CardHeader>
+            <CardContent>
+               <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                <li>Direct Sales Team</li>
+                <li>Partnerships with FAF and Leagues</li>
+                <li>Digital Marketing (Social Media, SEO)</li>
+                <li>Web Platform & App Stores</li>
+                <li>Word-of-mouth & Referrals</li>
+              </ul>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg"><Users className="h-5 w-5 text-primary" /> Customer Segments</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                <li>Professional Clubs (Ligue 1 & 2)</li>
+                <li>Football Academies</li>
+                <li>Professional Coaches & Analysts</li>
+                <li>National & Regional Federations</li>
+                <li>Scouting Agencies</li>
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Bottom Row */}
+        <div className="lg:col-span-3 grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-lg"><BarChart2 className="h-5 w-5 text-primary" /> Cost Structure</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                        <li>Salaries (Development, Support, Sales)</li>
+                        <li>Cloud Infrastructure & API Costs</li>
+                        <li>Marketing & Advertising Expenses</li>
+                        <li>Office & Administrative Costs</li>
+                        <li>R&D Investment</li>
+                    </ul>
+                </CardContent>
+            </Card>
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-lg"><DollarSign className="h-5 w-5 text-primary" /> Revenue Streams</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                        <li>Monthly/Annual SaaS Subscriptions (Premium)</li>
+                        <li>Pay-per-Match Fees</li>
+                        <li>Enterprise Licensing & Customization Fees</li>
+                        <li>Training & Certification Programs</li>
+                        <li>Data API Access (Future)</li>
+                    </ul>
+                </CardContent>
+            </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BusinessModelCanvasPage;

--- a/src/pages/BusinessPlanPage.tsx
+++ b/src/pages/BusinessPlanPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import BusinessPlanManagement from '@/components/admin/BusinessPlanManagement';
+
+const BusinessPlanPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-12 px-4 md:px-6">
+      <BusinessPlanManagement />
+    </div>
+  );
+};
+
+export default BusinessPlanPage;

--- a/src/pages/MarketIntelligencePage.tsx
+++ b/src/pages/MarketIntelligencePage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import MarketIntelligence from '@/components/scouting/MarketIntelligence';
+
+const MarketIntelligencePage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-12 px-4 md:px-6">
+      <MarketIntelligence />
+    </div>
+  );
+};
+
+export default MarketIntelligencePage;

--- a/src/pages/ServiceOffer.tsx
+++ b/src/pages/ServiceOffer.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { CheckCircle } from 'lucide-react';
+
+const formatCurrency = (amount: number) => {
+  return new Intl.NumberFormat('ar-DZ', {
+    style: 'currency',
+    currency: 'DZD',
+    minimumFractionDigits: 0
+  }).format(amount);
+};
+
+const ServiceOfferPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-12 px-4 md:px-6">
+      <div className="text-center mb-12">
+        <h1 className="text-4xl font-extrabold tracking-tight lg:text-5xl">Our Service Offers</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Choose the plan that best fits your club's needs and budget.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+        {/* Pay-per-Match Plan */}
+        <Card className="border-blue-200 flex flex-col">
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold text-blue-600">⚡ Pay-per-Match</CardTitle>
+          </CardHeader>
+          <CardContent className="flex-grow space-y-6">
+            <div className="text-4xl font-bold text-blue-600">
+              {formatCurrency(12000)}
+              <span className="text-lg font-medium text-muted-foreground">/match</span>
+            </div>
+            <p className="text-sm text-muted-foreground">Ideal for occasional needs and smaller clubs getting started with data analysis.</p>
+            <ul className="space-y-3 text-sm">
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Up to <strong>4 trackers</strong> maximum per match</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Access to all <strong>base statistics</strong> and reports</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Email support</span>
+              </li>
+            </ul>
+          </CardContent>
+          <div className="p-6 pt-0">
+            <Button className="w-full bg-blue-600 hover:bg-blue-700">Get Started</Button>
+          </div>
+        </Card>
+
+        {/* Premium Plan */}
+        <Card className="border-green-400 border-2 flex flex-col relative shadow-lg">
+          <Badge variant="default" className="absolute -top-3 left-1/2 -translate-x-1/2 bg-green-600">Most Popular</Badge>
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold text-green-600">💎 Abonnement Premium</CardTitle>
+          </CardHeader>
+          <CardContent className="flex-grow space-y-6">
+            <div className="text-4xl font-bold text-green-600">
+              {formatCurrency(85000)}
+              <span className="text-lg font-medium text-muted-foreground">/month</span>
+            </div>
+            <p className="text-sm text-muted-foreground">The complete solution for professional clubs serious about performance analysis.</p>
+            <ul className="space-y-3 text-sm">
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span><strong>Unlimited</strong> matches</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Up to <strong>8 simultaneous trackers</strong></span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Integrated <strong>voice chat</strong> for live collaboration</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span><strong>Advanced analytics</strong>, heatmaps, and visualizations</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Priority email and phone support</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span><strong>On-site team training</strong> included</span>
+              </li>
+            </ul>
+          </CardContent>
+          <div className="p-6 pt-0">
+            <Button className="w-full bg-green-600 hover:bg-green-700">Choose Premium</Button>
+          </div>
+        </Card>
+
+        {/* Enterprise Plan */}
+        <Card className="border-purple-200 flex flex-col">
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold text-purple-600">🏆 Enterprise</CardTitle>
+          </CardHeader>
+          <CardContent className="flex-grow space-y-6">
+            <div className="text-4xl font-bold text-purple-600">
+              {formatCurrency(150000)}
+              <span className="text-lg font-medium text-muted-foreground">/month</span>
+            </div>
+            <p className="text-sm text-muted-foreground">A fully customized, white-glove solution for federations and large clubs.</p>
+            <ul className="space-y-3 text-sm">
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span><strong>All Premium features</strong> plus...</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Custom-built features and integrations</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Dedicated 24/7 support channel</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>API access for data integration</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <CheckCircle className="h-5 w-5 text-green-500 mt-0.5 flex-shrink-0" />
+                <span>Continuous training and consultation</span>
+              </li>
+            </ul>
+          </CardContent>
+          <div className="p-6 pt-0">
+            <Button className="w-full bg-purple-600 hover:bg-purple-700">Contact Us</Button>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceOfferPage;

--- a/src/pages/StartupPitchPage.tsx
+++ b/src/pages/StartupPitchPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import StartupPitchPresentation from '@/components/admin/StartupPitchPresentation';
+
+const StartupPitchPage: React.FC = () => {
+  return (
+    <div className="container mx-auto py-12 px-4 md:px-6">
+      <StartupPitchPresentation />
+    </div>
+  );
+};
+
+export default StartupPitchPage;


### PR DESCRIPTION
This commit introduces a new suite of pages dedicated to business intelligence, as requested by the user. It adapts the concepts of a market study, business plan, presentation, business model canvas, and service offer into interactive webpages within the application.

- Creates five new page components in `src/pages/`:
  - `ServiceOffer.tsx`
  - `BusinessModelCanvas.tsx`
  - `MarketIntelligencePage.tsx`
  - `BusinessPlanPage.tsx`
  - `StartupPitchPage.tsx`
- Adds corresponding routes for these pages in `src/App.tsx`, protected by role-based access for admins and managers.
- Updates the sidebar navigation in `src/hooks/useMenuItems.ts` to include links to these new pages under a "Business" section.
- Fixes a pre-existing build error in `src/components/admin/ErrorManager.tsx` by correcting an import statement for the Supabase `User` type.