### PR TITLE
Fix: Correct Supabase client import path

### DIFF
--- a/src/components/CodeVisualizer.tsx
+++ b/src/components/CodeVisualizer.tsx
@@ -1,12 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import * as d3 from 'd3';
 import { Search, Upload, Github, Play, Pause, RotateCcw, ZoomIn, ZoomOut, Filter, Settings, AlertTriangle, CheckCircle, XCircle, Activity, Layers, GitBranch } from 'lucide-react';
-import { createClient } from '@integrations/supabase-js';
-
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+import { supabase } from '@/integrations/supabase/client';
 
 // Enhanced interfaces with modern TypeScript patterns
 interface CodebaseNode {


### PR DESCRIPTION
The build was failing due to an incorrect import path for the Supabase client in `src/components/CodeVisualizer.tsx`. The import path `@integrations/supabase-js` was invalid because there is no `@integrations` alias defined in the Vite configuration.

This change corrects the import path to use the existing `@` alias, pointing to `src/integrations/supabase/client`. It also removes the redundant local initialization of the Supabase client, as it is now imported directly.